### PR TITLE
(robot qnx install) Adjusting to https://github.com/start-jsk/rtmros_hironx/pull/198

### DIFF
--- a/hironx_ros_bridge/robot/robot-system-check.sh
+++ b/hironx_ros_bridge/robot/robot-system-check.sh
@@ -48,11 +48,11 @@ getent ahosts $hostname || (echo -e "-- [ERROR] Could find IP address/Host name 
 
 
 echo ";; Copying check script to $userid@$hostname:$TMPDIR"
-ssh  $userid@$hostname "touch /opt/jsk/.checked"
 ssh  $userid@$hostname "mkdir -p /tmp/$TMPDIR"
 scp  ./check/robot-system-check-base $userid@$hostname:/tmp/$TMPDIR/
 echo ";; Execute check scripts"
 ssh $userid@$hostname -t $commands 2>&1 | tee robot-system-check-$hostname.log
+ssh  $userid@$hostname "touch /opt/jsk/.checking"
 
 echo -e ";;\n;;\n;; Done check scripts, please check robot-system-check-$hostname.log file\n;;\n;;\n"
 


### PR DESCRIPTION
Currently [the file touched in `/opt/jsk` is "`.checked`"](https://github.com/k-okada/rtmros_hironx/blob/81d29cc98997ae0e1876c2cd3198ba1febcb2ad2/hironx_ros_bridge/robot/robot-system-check.sh#L51) but [the PReq checks `.checking`](https://github.com/start-jsk/rtmros_hironx/pull/198). It's easier to change what to check rather than the filename (that involves checksum to change).
